### PR TITLE
部署:

### DIFF
--- a/build/weapp/Weapp-Server.yaml
+++ b/build/weapp/Weapp-Server.yaml
@@ -326,7 +326,7 @@ metadata:
   name:  shoporder-service
   namespace: weapp-namespace
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     rollingUpdate:
       maxSurge: 10%
@@ -378,7 +378,7 @@ metadata:
   name:  goods-service
   namespace: weapp-namespace
 spec:
-  replicas: 1
+  replicas: 2
   strategy:
     rollingUpdate:
       maxSurge: 10%
@@ -476,19 +476,17 @@ spec:
     - name: prod-port
       port: 8080
 ---
-apiVersion: apps/v1beta2
-kind: StatefulSet
+apiVersion: extensions/v1beta1
+kind: Deployment
 metadata:
   name:  filecenter-service
   namespace: weapp-namespace
 spec:
-  selector:
-    matchLabels:
-      app: filecenter-service
-  replicas: 1
-  serviceName: filecenter-service
-  updateStrategy:
-    type: RollingUpdate
+  replicas: 3
+  strategy:
+    rollingUpdate:
+      maxSurge: 10%
+      maxUnavailable: 0
   template:
     metadata:
       labels:
@@ -519,16 +517,12 @@ spec:
               name: prod-port
           volumeMounts:
             - name: weapp-filecenter
-              mountPath: /root/store        
-  volumeClaimTemplates:
-    - metadata:
-        name: weapp-filecenter
-      spec:
-        accessModes: ["ReadWriteOnce"]
-        storageClassName: "managed-nfs-storage"
-        resources:
-          requests:
-            storage: 15Gi             
+              mountPath: /root/store
+      volumes:
+        - name: weapp-filecenter
+          nfs:
+            path: /var/nfs/weapp-namespace-weapp-filecenter-filecenter-service/
+            server: 192.168.0.102        
 ---
 apiVersion: v1
 kind: Service


### PR DESCRIPTION
1.2个shoporder-service实例,3个filecenter-service实例,2个goods-service实例
2.多个filecenter-service共享同一个nfs数据卷